### PR TITLE
UI for Confirmation Page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ import ErrorMessage from "./components/ErrorMessage";
 import NavBar from "./components/NavBar.jsx";
 import SuggestedValidators from "./components/SuggestedValidators/SuggestedValidators";
 import WalletConnect from "./components/WalletConnect/WalletConnect";
+import ConfirmationPage from "./components/ConfirmationPage/ConfirmationPage";
 
 const AMPLITUDE_KEY = "1f1699160a46dec6cc7514c14cb5c968";
 
@@ -192,6 +193,53 @@ function App() {
 		return <ErrorMessage />;
 	}
 
+	/* Beginning of Sample Validator List for UI Demonstration to be removed */
+	const sampleValidatorList = [
+		{
+			name: "PolyLabs 1",
+			avatar: "default",
+			amount: "1.25",
+			risk: "0.24"
+		},
+		{
+			name: "PolyLabs 2",
+			avatar: "default",
+			amount: "1.25",
+			risk: "0.3"
+		},
+		{
+			name: "PolyLabs 3",
+			avatar: "default",
+			amount: "1.25",
+			risk: "0.64"
+		},
+		{
+			name: "PolyLabs 4",
+			avatar: "default",
+			amount: "1.25",
+			risk: "0.34"
+		},
+		{
+			name: "PolyLabs 5",
+			avatar: "default",
+			amount: "1.25",
+			risk: "0.64"
+		},
+		{
+			name: "PolyLabs 6",
+			avatar: "default",
+			amount: "1.25",
+			risk: "0.44"
+		},
+		{
+			name: "PolyLabs 7",
+			avatar: "default",
+			amount: "1.25",
+			risk: "0.14"
+		}
+	];
+	/* End of Sample Validator List for UI Demonstration */
+
 	return (
 		<AmplitudeProvider
 			amplitudeInstance={amplitude.getInstance()}
@@ -347,55 +395,27 @@ function App() {
 							returns={1.43678534556}
 							budget={3000}
 							currency='KSM'
-							validatorsList={[
-								{
-									name: "PolyLabs 1",
-									avatar: "default",
-									amount: "1.25",
-									risk: "0.24"
-								},
-								{
-									name: "PolyLabs 2",
-									avatar: "default",
-									amount: "1.25",
-									risk: "0.3"
-								},
-								{
-									name: "PolyLabs 3",
-									avatar: "default",
-									amount: "1.25",
-									risk: "0.64"
-								},
-								{
-									name: "PolyLabs 4",
-									avatar: "default",
-									amount: "1.25",
-									risk: "0.34"
-								},
-								{
-									name: "PolyLabs 5",
-									avatar: "default",
-									amount: "1.25",
-									risk: "0.64"
-								},
-								{
-									name: "PolyLabs 6",
-									avatar: "default",
-									amount: "1.25",
-									risk: "0.44"
-								},
-								{
-									name: "PolyLabs 7",
-									avatar: "default",
-									amount: "1.25",
-									risk: "0.14"
-								}
-							]}
+							validatorsList={sampleValidatorList}
 						/>
 					</Route>
 					{/* PolkaWallet Connect */}
 					<Route path='/wallet-connect'>
 						<WalletConnect colorMode={colorMode} />
+					</Route>
+					{/* Confirmation */}
+					<Route path='/confirmation'>
+						<ConfirmationPage
+							colorMode={colorMode}
+							stashOptions={[{ option: "Account Name", value: "AccountID" }]}
+							controllerOptions={[
+								{ option: "Account Name", value: "AccountID" }
+							]}
+							riskPreference={0.5}
+							eras={4}
+							amount={3500}
+							currency='KSM'
+							validatorsList={sampleValidatorList}
+						/>
 					</Route>
 				</Flex>
 				{/* Validator specific view */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -411,6 +411,7 @@ function App() {
 								{ option: "Account Name", value: "AccountID" }
 							]}
 							riskPreference={0.5}
+							fees='10.0 milli'
 							eras={4}
 							amount={3500}
 							currency='KSM'

--- a/src/components/ConfirmationPage/ConfirmationPage.js
+++ b/src/components/ConfirmationPage/ConfirmationPage.js
@@ -35,6 +35,7 @@ type ConfirmationPageProps = {
 		amount: float,
 		risk?: float
 	}>,
+	fees: string,
 	eras: Number,
 	amount: float,
 	currency: string
@@ -87,8 +88,9 @@ const ConfirmationPage = (props: ConfirmationPageProps) => {
 							height='auto'
 							mb={8}
 						>
-							You are about to stake your KSM on the following validators.
-							Please make sure you understand the risks before proceeding.
+							You are about to stake your {props.currency} on the following
+							validators. Please make sure you understand the risks before
+							proceeding.
 						</Text>
 						<Flex align='center' wrap='wrap' my={2}>
 							<Text
@@ -205,8 +207,8 @@ const ConfirmationPage = (props: ConfirmationPageProps) => {
 								color={messageBoxColors[mode].text}
 								textAlign='center'
 							>
-								Fees of 10.000 milli KSM will be applied to the submission and
-								funds will be locked for {props.eras} eras
+								Fees of {props.fees} {props.currency} will be applied to the
+								submission and funds will be locked for {props.eras} eras
 							</Text>
 						</Box>
 						<Flex align='flex-start'>

--- a/src/components/ConfirmationPage/ConfirmationPage.js
+++ b/src/components/ConfirmationPage/ConfirmationPage.js
@@ -1,0 +1,290 @@
+import React from "react";
+import { Route } from "react-router-dom";
+import {
+	Box,
+	Heading,
+	Flex,
+	Text,
+	Link,
+	Icon,
+	Select,
+	Badge,
+	Checkbox,
+	Tooltip
+} from "@chakra-ui/core";
+import Helmet from "react-helmet";
+import Footer from "../Footer.jsx";
+import ValidatorTile from "../SuggestedValidators/ValidatorTile";
+import {
+	textColor,
+	textColorLight,
+	border,
+	getRiskLevelColor,
+	getRiskLevel
+} from "../../constants";
+import CustomButton from "../CustomButton";
+
+type ConfirmationPageProps = {
+	colorMode?: "light" | "dark",
+	stashOptions: Array<{ option: string, value: string }>,
+	controllerOptions: Array<{ option: string, value: string }>,
+	riskPreference: string,
+	validatorsList: Array<{
+		name: string,
+		avatar?: string,
+		amount: float,
+		risk?: float
+	}>,
+	eras: Number,
+	amount: float,
+	currency: string
+};
+
+const messageBoxColors = {
+	light: {
+		bg: "#E0F4FF",
+		border: "#C1E9FF",
+		text: "#89BEDC"
+	},
+	dark: {
+		bg: "#354056",
+		border: "#678AD1",
+		text: "#CCDDFF"
+	}
+};
+
+const ConfirmationPage = (props: ConfirmationPageProps) => {
+	const mode = props.colorMode ? props.colorMode : "light";
+
+	const [termsCheck, setTermsCheck] = React.useState(false);
+
+	return (
+		<>
+			<Helmet>
+				<title>Yield Scan &middot; Confirmation</title>
+			</Helmet>
+			<Route exact path='/confirmation'>
+				<Box m={4} mt={10}>
+					<Link m={4}>
+						<Icon name='arrow-back' mr={1} /> Back
+					</Link>
+				</Box>
+				<Flex w='100%' justify='center'>
+					<Box w={["100%", "80%", "60%", "50%"]}>
+						<Heading
+							as='h3'
+							size='xl'
+							textAlign='center'
+							color={textColor[mode]}
+						>
+							Confirmation
+						</Heading>
+						<Text
+							size='sm'
+							color={textColorLight[mode]}
+							textAlign='center'
+							w='100%'
+							height='auto'
+							mb={8}
+						>
+							You are about to stake your KSM on the following validators.
+							Please make sure you understand the risks before proceeding.
+						</Text>
+						<Flex align='center' wrap='wrap' my={2}>
+							<Text
+								color={textColorLight[mode]}
+								my={2}
+								w={["100%", "150px", "200px", "200px"]}
+							>
+								Stash Account
+							</Text>
+							<Select
+								placeholder='Select Account'
+								w={[
+									"calc(100%)",
+									"calc(100% - 150px)",
+									"calc(100% - 200px)",
+									"calc(100% - 200px)"
+								]}
+							>
+								{props.stashOptions.map((doc, index) => {
+									return (
+										<option value={doc.value} key={index}>
+											{doc.option}
+										</option>
+									);
+								})}
+							</Select>
+						</Flex>
+						<Flex align='center' wrap='wrap' my={2}>
+							<Text
+								color={textColorLight[mode]}
+								my={2}
+								w={["100%", "150px", "200px", "200px"]}
+							>
+								Controller Account
+							</Text>
+							<Select
+								placeholder='Select Account'
+								w={[
+									"calc(100%)",
+									"calc(100% - 150px)",
+									"calc(100% - 200px)",
+									"calc(100% - 200px)"
+								]}
+							>
+								{props.controllerOptions.map((doc, index) => {
+									return (
+										<option value={doc.value} key={index}>
+											{doc.option}
+										</option>
+									);
+								})}
+							</Select>
+						</Flex>
+						<Flex align='center' wrap='wrap' my={2}>
+							<Text
+								color={textColorLight[mode]}
+								my={2}
+								w={["100%", "150px", "200px", "200px"]}
+							>
+								Risk Preference
+							</Text>
+							<Badge
+								mx={1}
+								px={3}
+								py={1}
+								fontSize='sm'
+								variantColor={getRiskLevelColor(props.riskPreference)}
+							>
+								{getRiskLevel(props.riskPreference)}
+							</Badge>
+						</Flex>
+						<Box w='100%' p={2} mt={6} h='50vh' overflow='auto'>
+							{props.validatorsList.map((validator, index) => {
+								return (
+									<ValidatorTile
+										key={index}
+										name={validator.name}
+										amount={validator.amount}
+										currency={props.currency}
+										avatar={validator.avatar}
+										colorMode={props.colorMode}
+									/>
+								);
+							})}
+						</Box>
+						<Text
+							textAlign='center'
+							color={textColorLight[mode]}
+							my={4}
+							fontSize='xs'
+						>
+							* the estimated daily earnings are indicative. Actual rewards may
+							vary.
+						</Text>
+						<Box
+							p={4}
+							my={4}
+							w='100%'
+							bg={messageBoxColors[mode].bg}
+							borderColor={messageBoxColors[mode].border}
+							borderWidth='1px'
+							rounded='md'
+						>
+							<Text
+								fontSize='xs'
+								color={messageBoxColors[mode].text}
+								textAlign='center'
+							>
+								Fees of 10.000 milli KSM will be applied to the submission and
+								funds will be locked for {props.eras} eras
+							</Text>
+						</Box>
+						<Flex align='flex-start'>
+							<Checkbox
+								mx={4}
+								my={1}
+								variantColor='blue'
+								size='lg'
+								isChecked={termsCheck}
+								onChange={e => {
+									setTermsCheck(!termsCheck);
+								}}
+							></Checkbox>
+							<Text fontSize='sm' color={textColorLight[mode]}>
+								I understand that the funds will be bonded, meaning the tokens
+								would be locked for a period of time and can only be redeemed
+								after that period ends, and could be slashed if the validators I
+								nominate misbehave.
+							</Text>
+						</Flex>
+						<Flex
+							w='100%'
+							px={2}
+							py={0}
+							my={4}
+							bg={border[mode]}
+							borderWidth='2px'
+							rounded='lg'
+							align='center'
+							justify='center'
+							wrap='wrap'
+						>
+							<Box
+								w={[
+									"calc(50% - 1rem)",
+									"calc(50% - 1rem)",
+									"calc(50% - 1rem)",
+									"calc(50% - 1rem)"
+								]}
+								p={4}
+							>
+								<Text color={textColor[mode]} w='100%'>
+									<b>Amount</b>
+								</Text>
+								<Text color={textColorLight[mode]} fontSize='2xl' w='100%'>
+									{props.amount}
+								</Text>
+							</Box>
+							<Box
+								w={[
+									"calc(50% - 1rem)",
+									"calc(50% - 1rem)",
+									"calc(50% - 1rem)",
+									"calc(50% - 1rem)"
+								]}
+								p={4}
+							>
+								<Text color={textColor[mode]} w='100%'>
+									<b>Currency</b>
+								</Text>
+								<Text color={textColorLight[mode]} fontSize='xl' w='100%'>
+									{props.currency}
+								</Text>
+							</Box>
+						</Flex>
+						<Flex justify='center' py={2} wrap='wrap'>
+							<CustomButton disable={!termsCheck}>Submit</CustomButton>
+							{!termsCheck && (
+								<Text
+									textAlign='center'
+									w='100%'
+									m={2}
+									fontSize='xs'
+									as='i'
+									color={textColorLight[mode]}
+								>
+									Please agree to the terms before submitting
+								</Text>
+							)}
+						</Flex>
+					</Box>
+				</Flex>
+			</Route>
+			<Footer />
+		</>
+	);
+};
+
+export default ConfirmationPage;

--- a/src/components/ConfirmationPage/ConfirmationPage.js
+++ b/src/components/ConfirmationPage/ConfirmationPage.js
@@ -109,7 +109,11 @@ const ConfirmationPage = (props: ConfirmationPageProps) => {
 							>
 								{props.stashOptions.map((doc, index) => {
 									return (
-										<option value={doc.value} key={index}>
+										<option
+											style={{ color: "#000" }}
+											value={doc.value}
+											key={index}
+										>
 											{doc.option}
 										</option>
 									);
@@ -135,7 +139,11 @@ const ConfirmationPage = (props: ConfirmationPageProps) => {
 							>
 								{props.controllerOptions.map((doc, index) => {
 									return (
-										<option value={doc.value} key={index}>
+										<option
+											value={doc.value}
+											key={index}
+											style={{ color: "#000" }}
+										>
 											{doc.option}
 										</option>
 									);

--- a/src/components/ConfirmationPage/ConfirmationPage.js
+++ b/src/components/ConfirmationPage/ConfirmationPage.js
@@ -222,7 +222,10 @@ const ConfirmationPage = (props: ConfirmationPageProps) => {
 									setTermsCheck(!termsCheck);
 								}}
 							></Checkbox>
-							<Text fontSize='sm' color={textColorLight[mode]}>
+							<Text
+								fontSize={["xs", "xs", "sm", "sm"]}
+								color={textColorLight[mode]}
+							>
 								I understand that the funds will be bonded, meaning the tokens
 								would be locked for a period of time and can only be redeemed
 								after that period ends, and could be slashed if the validators I

--- a/src/components/ConfirmationPage/ConfirmationPage.js
+++ b/src/components/ConfirmationPage/ConfirmationPage.js
@@ -110,7 +110,7 @@ const ConfirmationPage = (props: ConfirmationPageProps) => {
 								{props.stashOptions.map((doc, index) => {
 									return (
 										<option
-											style={{ color: "#000" }}
+											style={{ color: "#000", background: "#FFF" }}
 											value={doc.value}
 											key={index}
 										>
@@ -142,7 +142,7 @@ const ConfirmationPage = (props: ConfirmationPageProps) => {
 										<option
 											value={doc.value}
 											key={index}
-											style={{ color: "#000" }}
+											style={{ color: "#000", background: "#FFF" }}
 										>
 											{doc.option}
 										</option>

--- a/src/components/CustomButton.js
+++ b/src/components/CustomButton.js
@@ -1,35 +1,59 @@
 import React from "react";
 import { PseudoBox } from "@chakra-ui/core";
 
+const colorScheme = {
+	primary: {
+		bg: "#19CC95",
+		color: "#FFF",
+		hoverBg: "#14AC7D"
+	},
+	secondary: {
+		bg: "#4A5567",
+		color: "#FFF",
+		hoverBg: "#2F3745"
+	},
+	white: {
+		bg: "#FFF",
+		color: "#19CC95",
+		hoverBg: "#EEE"
+	}
+};
+
 type CustomButtonProps = {
-	variant?: "primary" | "secondary"
+	variant?: "primary" | "secondary" | "white",
+	disable?: Boolean
 };
 
 const CustomButton = (props: CustomButtonProps) => {
-	let variant = props.variant ? props.variant : "primary";
+	const variant = props.variant ? props.variant : "primary";
 	return (
 		<>
 			<PseudoBox
 				as='button'
 				transition='all 0.2s cubic-bezier(.08,.52,.52,1)'
-				px={6}
+				px={8}
 				py={3}
 				m={1}
 				rounded='50px'
 				fontSize='md'
 				outline='none'
 				fontWeight='semibold'
-				bg={variant === "primary" ? "#19CC95" : "#4A5567"}
-				color='#FFF'
-				_hover={{ bg: variant === "primary" ? "#14AC7D" : "#2F3745" }}
+				bg={colorScheme[variant].bg}
+				color={colorScheme[variant].color}
+				_hover={{ bg: colorScheme[variant].hoverBg }}
 				_active={{
-					bg: variant === "primary" ? "#14AC7D" : "#2F3745",
+					bg: colorScheme[variant].hoverBg,
 					transform: "scale(0.96)",
 					borderColor: "#bec3c9"
 				}}
 				_focus={{
 					boxShadow:
 						"0 0 1px 4px rgba(25, 204, 149, .5), 0 1px 1px rgba(0, 0, 0, .15)"
+				}}
+				disabled={props.disable}
+				_disabled={{
+					pointerEvents: "none",
+					opacity: "0.5"
 				}}
 			>
 				{props.children}

--- a/src/components/SuggestedValidators/SuggestedValidators.js
+++ b/src/components/SuggestedValidators/SuggestedValidators.js
@@ -32,7 +32,7 @@ const SuggestedValidators = (props: SuggestedValidatorsProps) => {
 	return (
 		<React.Fragment>
 			<Helmet>
-				<title>Suggested Validators</title>
+				<title>Yield Scan &middot; Suggested Validators</title>
 			</Helmet>
 			<Route exact path='/suggested-validators'>
 				<Box m={4} mt={10}>
@@ -62,6 +62,7 @@ const SuggestedValidators = (props: SuggestedValidatorsProps) => {
 							{props.validatorsList.map((validator, index) => {
 								return (
 									<ValidatorTile
+										key={index}
 										name={validator.name}
 										amount={validator.amount}
 										risk={validator.risk}

--- a/src/components/SuggestedValidators/ValidatorTile.js
+++ b/src/components/SuggestedValidators/ValidatorTile.js
@@ -43,13 +43,17 @@ const ValidatorTile = (props: ValidatorTileProps) => {
 						</Heading>
 						<Text color={textColor[props.colorMode]} fontSize='sm'>
 							Staking Amount: {props.amount} {props.currency}
-							<Text as='i' color={textColorLight[props.colorMode]} mx={1}>
-								|
-							</Text>
-							Risk Score:
-							<Badge mx={2} fontSize='sm' variantColor={riskBadge}>
-								{props.risk}
-							</Badge>
+							{props.risk && (
+								<Text>
+									<Text as='i' color={textColorLight[props.colorMode]} mx={1}>
+										|
+									</Text>
+									Risk Score:
+									<Badge mx={2} fontSize='sm' variantColor={riskBadge}>
+										{props.risk}
+									</Badge>
+								</Text>
+							)}
 						</Text>
 					</Box>
 				</Flex>

--- a/src/components/WalletConnect/WalletConnect.js
+++ b/src/components/WalletConnect/WalletConnect.js
@@ -23,9 +23,9 @@ type WalletConnectProps = {
 const WalletConnect = (props: WalletConnectProps) => {
 	const mode = props.colorMode ? props.colorMode : "light";
 	return (
-		<React.Fragment>
+		<>
 			<Helmet>
-				<title>Suggested Validators</title>
+				<title>Yield Scan &middot; Wallet Connect</title>
 			</Helmet>
 			<Route exact path='/wallet-connect'>
 				<Box m={4} mt={10}>
@@ -123,7 +123,7 @@ const WalletConnect = (props: WalletConnectProps) => {
 				</Box>
 			</Route>
 			<Footer />
-		</React.Fragment>
+		</>
 	);
 };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,23 +5,38 @@ const HIGH_RISK = 1;
 const getRiskLevelColor = risk => {
 	if (risk < LOW_RISK) {
 		return "green";
-	} else if (risk < MED_RISK) {
-		return "yellow";
-	} else if (risk < HIGH_RISK) {
-		return "red";
-	} else {
-		return "gray";
 	}
+	if (risk < MED_RISK) {
+		return "yellow";
+	}
+	if (risk < HIGH_RISK) {
+		return "red";
+	}
+	return "gray";
+};
+
+const getRiskLevel = risk => {
+	if (risk < LOW_RISK) {
+		return "LOW";
+	}
+	if (risk < MED_RISK) {
+		return "MEDIUM";
+	}
+	if (risk < HIGH_RISK) {
+		return "HIGH";
+	}
+	return "UNKNOWN";
 };
 
 const textColor = { light: "2D3748", dark: "#FFF" };
-const textColorLight = { light: "#677793", dark: "#9DAECF" };
+const textColorLight = { light: "#677793", dark: "#ADB8CD" };
 const border = { light: "#EEF2F9", dark: "#262E3E" };
 
 export {
 	LOW_RISK,
 	HIGH_RISK,
 	getRiskLevelColor,
+	getRiskLevel,
 	textColor,
 	textColorLight,
 	border


### PR DESCRIPTION
This PR adds the UI for the Wallet Connect view:

Route for local testing: http://localhost:3000/#/confirmation

![screencapture-localhost-3000-2020-05-07-18_04_05](https://user-images.githubusercontent.com/6816349/81294920-33ad3800-908d-11ea-8f98-4ed75aa0c202.png)

**Description:**
Props:
- stashOptions: An array of objects that represents the list of options available under the select input to select stash accounts
- controllerOptions: An array of objects that represents the list of options available under the select input to select controller accounts
- riskPreference: takes in the generalized float risk value (that is derived from the slider in the calculator view). This value is then translated to HIGH, MEDIUM, or LOW through a helper function in constants (with appropriate badge color)
- validatorsList: array of objects representing the finally selected validators. (The structure of the object remains the same.)
- eras: to specify the number of eras that will be locked, as displayed in a disclaimer box in the UI
- amount: to specify the total amount/budget
- currency: to specify the currency as a string
- colorMode: to accomodate light and dark color modes

**Features:**
- [x] (almost) Dark mode compatible color schema (an issue with the select component exists in ChakraUI for Windows users. To be resolved in a future issue/PR)
- [x] Responsive
- [x] Submit button operates only when the terms are checked

Notes: This PR also adds variants to existing components, such as a white variant of our CustomButton, as well as cleans the code for some existing components. The PR also addresses the incorrect page titles that were missed by me in the previous PR. 
