### PR TITLE
UI for Edit Validators View

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,10 +38,11 @@ import NavBar from "./components/NavBar.jsx";
 import SuggestedValidators from "./components/SuggestedValidators/SuggestedValidators";
 import WalletConnect from "./components/WalletConnect/WalletConnect";
 import ConfirmationPage from "./components/ConfirmationPage/ConfirmationPage";
+import EditValidators from "./components/EditValidators/EditValidators";
 
 const AMPLITUDE_KEY = "1f1699160a46dec6cc7514c14cb5c968";
 
-const currency = 'KSM';
+const currency = "KSM";
 
 function App() {
 	// eslint-disable-next-line no-unused-vars
@@ -59,10 +60,12 @@ function App() {
 	const [stakeAmount] = useDebounce(stakeInput, 500.0);
 	const [apiConnected, setApiConnected] = React.useState(false);
 	const [isLoaded, setIsLoaded] = React.useState(false);
-	const [validators, setValidators] = React.useState([{name: 'None', stashId: "", amount: 0, risk: 0.00}]);
+	const [validators, setValidators] = React.useState([
+		{ name: "None", stashId: "", amount: 0, risk: 0.0 }
+	]);
 	const [suggValidatorsData, setSuggValidatorsData] = React.useState({
-		'budget' : '0',
-		'expectedReturns': '0'
+		budget: "0",
+		expectedReturns: "0"
 	});
 
 	const {
@@ -75,7 +78,7 @@ function App() {
 		onOpen: onCreateAccountDialogOpen,
 		onClose: onCreateAccountDialogClose
 	} = useDisclosure();
-	
+
 	const ERA_PER_DAY = 4;
 	const calcReward = React.useCallback(() => {
 		const data = validatorData.map(validator => {
@@ -109,7 +112,6 @@ function App() {
 		if (apiConnected) setIsLoaded(true);
 	}, [stakeAmount, validatorData, apiConnected]);
 
-
 	React.useEffect(() => {
 		if (apiConnected) {
 			calcReward();
@@ -117,12 +119,20 @@ function App() {
 	}, [calcReward, apiConnected]);
 
 	React.useEffect(() => {
-		let validatorsInfo = suggValidatorsData && suggValidatorsData.validatorsList && suggValidatorsData.validatorsList.reduce((acc, cur) => {
-			// TODO: Replace placeholder risk score with actual risk score
-			acc.push({name: cur.name, stashId: cur.stashId, amount: parseFloat(suggValidatorsData.budget)/16, risk: '0.22'});
-			return acc;
-		},[]);	
-		setValidators (validatorsInfo);
+		let validatorsInfo =
+			suggValidatorsData &&
+			suggValidatorsData.validatorsList &&
+			suggValidatorsData.validatorsList.reduce((acc, cur) => {
+				// TODO: Replace placeholder risk score with actual risk score
+				acc.push({
+					name: cur.name,
+					stashId: cur.stashId,
+					amount: parseFloat(suggValidatorsData.budget) / 16,
+					risk: "0.22"
+				});
+				return acc;
+			}, []);
+		setValidators(validatorsInfo);
 	}, [suggValidatorsData]);
 
 	React.useEffect(() => {
@@ -163,17 +173,17 @@ function App() {
 			}
 		);
 	}, []);
-	const [click, setClick] = React.useState(false); 
+	const [click, setClick] = React.useState(false);
 	if (errorState) {
 		return <ErrorMessage />;
 	}
 
 	function handleChildTabEvent(data) {
-		setSuggValidatorsData ({...data});
+		setSuggValidatorsData({ ...data });
 	}
 
 	function handleButtonClick(data) {
-		setClick (data);
+		setClick(data);
 	}
 
 	return (
@@ -335,24 +345,32 @@ function App() {
 						<HelpCenter />
 					</Route>
 					{/* Suggested Validators */}
-					{
-					click===true ?
-					<Route path='/suggested-validators'>
-						<SuggestedValidators
-							colorMode={colorMode}
-							returns={parseFloat(suggValidatorsData.expectedReturns)}
-							budget={parseFloat(suggValidatorsData.budget)}
-							currency={currency}
-							validatorsList={validators}
-							click={click}
-						/>
-					</Route>
-					:
-					<Redirect to="/" />
-					}
+					{click === true ? (
+						<Route path='/suggested-validators'>
+							<SuggestedValidators
+								colorMode={colorMode}
+								returns={parseFloat(suggValidatorsData.expectedReturns)}
+								budget={parseFloat(suggValidatorsData.budget)}
+								currency={currency}
+								validatorsList={validators}
+								click={click}
+							/>
+						</Route>
+					) : (
+						<Redirect to='/' />
+					)}
 					{/* PolkaWallet Connect */}
 					<Route path='/wallet-connect'>
 						<WalletConnect colorMode={colorMode} />
+					</Route>
+					{/* Edit Validators */}
+					<Route path='/edit-validators'>
+						<EditValidators
+							colorMode={colorMode}
+							currency={currency}
+							amount={16.5}
+							nValidators={16}
+						/>
 					</Route>
 					{/* Confirmation */}
 					<Route path='/confirmation'>
@@ -370,7 +388,7 @@ function App() {
 							validatorsList={validators}
 						/>
 					</Route>
-					<Route  render={() => (<Redirect to="/" />)} />
+					<Route render={() => <Redirect to='/' />} />
 				</Flex>
 				{/* Validator specific view */}
 				<Route

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -369,7 +369,6 @@ function App() {
 							colorMode={colorMode}
 							currency={currency}
 							amount={16.5}
-							nValidators={16}
 						/>
 					</Route>
 					{/* Confirmation */}

--- a/src/components/EditValidators/EditValidators.js
+++ b/src/components/EditValidators/EditValidators.js
@@ -18,8 +18,7 @@ import { textColor, textColorLight, border } from "../../constants";
 type EditValidatorsProps = {
 	colorMode?: "light" | "dark",
 	amount: float,
-	currency: string,
-	nValidators: number
+	currency: string
 };
 
 const EditValidators = (props: EditValidatorsProps) => {
@@ -124,7 +123,13 @@ const EditValidators = (props: EditValidatorsProps) => {
 						<b>
 							{props.amount} {props.currency}
 						</b>{" "}
-						to {props.nValidators} validators
+						to{" "}
+						{
+							validators.filter(doc => {
+								return doc.selected === true;
+							}).length
+						}{" "}
+						validators
 					</Text>
 					<Box w='100%' mt={8} overflow='auto'>
 						<Box w={["300%", "200%", "100%", "100%"]}>

--- a/src/components/EditValidators/EditValidators.js
+++ b/src/components/EditValidators/EditValidators.js
@@ -13,7 +13,7 @@ import Helmet from "react-helmet";
 import Footer from "../Footer.jsx";
 import Table from "./Table";
 import CustomButton from "../CustomButton";
-import { textColor, textColorLight, border } from "../../constants";
+import { textColor, textColorLight } from "../../constants";
 
 type EditValidatorsProps = {
 	colorMode?: "light" | "dark",
@@ -25,62 +25,42 @@ const EditValidators = (props: EditValidatorsProps) => {
 	const [validators, setValidators] = React.useState([
 		{
 			Validator: "PolyLabs I",
-			"Staking Amt.": "13.4525 KSM",
 			"Other Stake": "13.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			Points: "220",
+			"Own Stake": "13 KSM",
+			Commission: "4%",
 			"Risk Score": 0.34,
 			selected: true
 		},
 		{
 			Validator: "PolyLabs I",
-			"Staking Amt.": "13.4525 KSM",
 			"Other Stake": "13.4525 KSM",
 			"Own Stake": "12 KSM",
-			Commission: "3%",
-			Points: "220",
-			"Risk Score": 0.1,
+			Commission: "5%",
+			"Risk Score": 0.14,
 			selected: true
 		},
 		{
 			Validator: "PolyLabs I",
-			"Staking Amt.": "13.4525 KSM",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "12 KSM",
+			"Other Stake": "124.4525 KSM",
+			"Own Stake": "15 KSM",
 			Commission: "3%",
-			Points: "220",
-			"Risk Score": 0.7,
+			"Risk Score": 0.22,
 			selected: true
 		},
 		{
 			Validator: "PolyLabs I",
-			"Staking Amt.": "13.4525 KSM",
 			"Other Stake": "13.4525 KSM",
 			"Own Stake": "12 KSM",
-			Commission: "3%",
-			Points: "220",
-			"Risk Score": 0.7,
+			Commission: "2%",
+			"Risk Score": 0.15,
 			selected: true
 		},
 		{
 			Validator: "PolyLabs I",
-			"Staking Amt.": "13.4525 KSM",
-			"Other Stake": "13.4525 KSM",
+			"Other Stake": "53.4525 KSM",
 			"Own Stake": "12 KSM",
 			Commission: "3%",
-			Points: "220",
-			"Risk Score": 0.7,
-			selected: true
-		},
-		{
-			Validator: "PolyLabs I",
-			"Staking Amt.": "13.4525 KSM",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			Points: "220",
-			"Risk Score": 0.7,
+			"Risk Score": 0.64,
 			selected: true
 		}
 	]);
@@ -88,11 +68,9 @@ const EditValidators = (props: EditValidatorsProps) => {
 	const mode = props.colorMode ? props.colorMode : "light";
 
 	const callBack = i => {
-		console.log(i);
 		let temp = [...validators];
 		temp[i]["selected"] = temp[i]["selected"] ? !temp[i]["selected"] : true;
 		setValidators(temp);
-		console.log(validators);
 	};
 
 	const selectAll = bool => {
@@ -101,6 +79,20 @@ const EditValidators = (props: EditValidatorsProps) => {
 				return { ...doc, selected: bool };
 			})
 		);
+	};
+
+	const sortList = (column, asc) => {
+		let tempValidators = [...validators];
+		if (asc) {
+			tempValidators = tempValidators.sort((a, b) =>
+				a[column] > b[column] ? 1 : b[column] > a[column] ? -1 : 0
+			);
+		} else {
+			tempValidators = tempValidators.sort((a, b) =>
+				a[column] > b[column] ? -1 : b[column] > a[column] ? 1 : 0
+			);
+		}
+		setValidators(tempValidators);
 	};
 
 	return (
@@ -138,17 +130,21 @@ const EditValidators = (props: EditValidatorsProps) => {
 								allowRowSelect={true}
 								columns={[
 									"Validator",
-									"Staking Amt.",
 									"Other Stake",
 									"Own Stake",
 									"Commission",
-									"Points",
-									"Risk Score",
-									"Last #"
+									"Risk Score"
 								]}
 								rows={validators}
 								selectCallback={callBack}
 								selectAllCallback={selectAll}
+								sortableColumns={[
+									"Other Stake",
+									"Own Stake",
+									"Commission",
+									"Risk Score"
+								]}
+								sortCallback={sortList}
 							></Table>
 						</Box>
 					</Box>

--- a/src/components/EditValidators/EditValidators.js
+++ b/src/components/EditValidators/EditValidators.js
@@ -1,0 +1,162 @@
+import React from "react";
+import { Route } from "react-router-dom";
+import {
+	Box,
+	Heading,
+	Text,
+	Link,
+	Icon,
+	ButtonGroup,
+	Flex
+} from "@chakra-ui/core";
+import Helmet from "react-helmet";
+import Footer from "../Footer.jsx";
+import Table from "./Table";
+import CustomButton from "../CustomButton";
+import { textColor, textColorLight, border } from "../../constants";
+
+type EditValidatorsProps = {
+	colorMode?: "light" | "dark",
+	amount: float,
+	currency: string,
+	nValidators: number
+};
+
+const EditValidators = (props: EditValidatorsProps) => {
+	const [validators, setValidators] = React.useState([
+		{
+			Validator: "PolyLabs I",
+			"Staking Amt.": "13.4525 KSM",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			Points: "220",
+			"Risk Score": 0.34,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Staking Amt.": "13.4525 KSM",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			Points: "220",
+			"Risk Score": 0.1,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Staking Amt.": "13.4525 KSM",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			Points: "220",
+			"Risk Score": 0.7,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Staking Amt.": "13.4525 KSM",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			Points: "220",
+			"Risk Score": 0.7,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Staking Amt.": "13.4525 KSM",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			Points: "220",
+			"Risk Score": 0.7,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Staking Amt.": "13.4525 KSM",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			Points: "220",
+			"Risk Score": 0.7,
+			selected: true
+		}
+	]);
+
+	const mode = props.colorMode ? props.colorMode : "light";
+
+	const callBack = i => {
+		console.log(i);
+		let temp = [...validators];
+		temp[i]["selected"] = temp[i]["selected"] ? !temp[i]["selected"] : true;
+		setValidators(temp);
+		console.log(validators);
+	};
+
+	const selectAll = bool => {
+		setValidators(
+			validators.map((doc, i) => {
+				return { ...doc, selected: bool };
+			})
+		);
+	};
+
+	return (
+		<>
+			<Helmet>
+				<title>Yield Scan &middot; Edit Validators</title>
+			</Helmet>
+			<Route exact path='/edit-validators'>
+				<Box m={0} my={10}>
+					<Link to='/suggested-validators' m={0}>
+						<Icon name='arrow-back' mr={1} /> Suggested Validators
+					</Link>
+				</Box>
+				<Box w='100%'>
+					<Heading as='h3' size='xl' color={textColor[mode]}>
+						Edit Validators
+					</Heading>
+					<Text color={textColorLight[mode]}>
+						Staking a budget of{" "}
+						<b>
+							{props.amount} {props.currency}
+						</b>{" "}
+						to {props.nValidators} validators
+					</Text>
+					<Box w='100%' mt={8} overflow='auto'>
+						<Box w={["300%", "200%", "100%", "100%"]}>
+							<Table
+								colorMode={mode}
+								allowRowSelect={true}
+								columns={[
+									"Validator",
+									"Staking Amt.",
+									"Other Stake",
+									"Own Stake",
+									"Commission",
+									"Points",
+									"Risk Score",
+									"Last #"
+								]}
+								rows={validators}
+								selectCallback={callBack}
+								selectAllCallback={selectAll}
+							></Table>
+						</Box>
+					</Box>
+					<Flex justify='center' mt={4} py={4}>
+						<ButtonGroup spacing={4}>
+							<CustomButton>Proceed</CustomButton>
+						</ButtonGroup>
+					</Flex>
+				</Box>
+			</Route>
+			<Footer />
+		</>
+	);
+};
+
+export default EditValidators;

--- a/src/components/EditValidators/Table.js
+++ b/src/components/EditValidators/Table.js
@@ -1,0 +1,153 @@
+import React from "react";
+import {
+	Box,
+	Grid,
+	Text,
+	Checkbox,
+	Flex,
+	Badge,
+	Tooltip
+} from "@chakra-ui/core";
+import {
+	textColor,
+	textColorLight,
+	border,
+	getRiskLevelColor
+} from "../../constants";
+
+const deselect = {
+	light: "#F9FBFF",
+	dark: "#212937"
+};
+
+type TableProps = {
+	colorMode?: colorMode,
+	columns: Array<string>,
+	rows: Array<Object>,
+	allowRowSelect?: Boolean,
+	columnsTemplate?: string,
+	selectCallback?: Number => void,
+	selectAllCallback?: Boolean => void
+};
+
+const Table = (props: TableProps) => {
+	const [selectAll, setSelectAll] = React.useState(false);
+
+	const mode = props.colorMode ? props.colorMode : "light";
+	let columnTemplate = props.columnsTemplate
+		? props.columnsTemplate
+		: props.allowRowSelect
+		? `50px repeat(${props.columns.length}, 1fr)`
+		: `repeat(${props.columns.length}, 1fr)`;
+
+	return (
+		<>
+			<Box w='100%' h='100%' overflow='auto'>
+				<Grid
+					w='100%'
+					templateColumns={columnTemplate}
+					gap={0}
+					borderWidth='1px'
+					borderColor={border[mode]}
+					roundedTopLeft='lg'
+					roundedTopRight='lg'
+					boxShadow='0 0 25px rgba(0,0,0,.1)'
+				>
+					{props.allowRowSelect && (
+						<Tooltip
+							label={selectAll ? "Deselect All" : "Select All"}
+							placement='bottom'
+							hasArrow
+						>
+							<Flex
+								w='100% - 10px'
+								px='10px'
+								py={4}
+								align='center'
+								justify='center'
+							>
+								<Checkbox
+									size='lg'
+									variantColor='teal'
+									isChecked={selectAll}
+									onChange={e => {
+										setSelectAll(!selectAll);
+										props.selectAllCallback(!selectAll);
+									}}
+								></Checkbox>
+							</Flex>
+						</Tooltip>
+					)}
+					{props.columns.map((col, index) => {
+						return (
+							<Box w='calc(100% - 10px)' p='10px' key={index}>
+								<Text as='b' fontSize='sm' color={textColor[mode]}>
+									{col}
+								</Text>
+							</Box>
+						);
+					})}
+				</Grid>
+				{props.rows.map((row, index) => {
+					return (
+						<Grid
+							key={index}
+							templateColumns={columnTemplate}
+							gap={0}
+							borderWidth='1px'
+							borderColor={border[mode]}
+							borderTop='0'
+							bg={row.selected ? "rgba(255,255,255,0)" : deselect[mode]}
+						>
+							{props.allowRowSelect && (
+								<Flex
+									w='100% - 10px'
+									px='10px'
+									py={4}
+									align='center'
+									justify='center'
+								>
+									<Checkbox
+										size='lg'
+										key={"Check" + index}
+										variantColor='teal'
+										isChecked={row.selected}
+										onChange={e => {
+											if (row.selected) {
+												setSelectAll(false);
+											}
+											props.selectCallback(index);
+										}}
+									></Checkbox>
+								</Flex>
+							)}
+							{props.columns.map((col, i) => {
+								return (
+									<Box w='calc(100% - 10px)' px='10px' py={4} key={i}>
+										{col === "Risk Score" ? (
+											<Text fontSize='sm'>
+												<Badge variantColor={getRiskLevelColor(row[col])}>
+													{row[col]}
+												</Badge>
+											</Text>
+										) : (
+											<Text
+												fontSize='sm'
+												color={textColorLight[mode]}
+												as={col === "Validator" ? "b" : "p"}
+											>
+												{row[col]}
+											</Text>
+										)}
+									</Box>
+								);
+							})}
+						</Grid>
+					);
+				})}
+			</Box>
+		</>
+	);
+};
+
+export default Table;

--- a/src/components/EditValidators/Table.js
+++ b/src/components/EditValidators/Table.js
@@ -6,7 +6,9 @@ import {
 	Checkbox,
 	Flex,
 	Badge,
-	Tooltip
+	Tooltip,
+	Stack,
+	IconButton
 } from "@chakra-ui/core";
 import {
 	textColor,
@@ -27,7 +29,9 @@ type TableProps = {
 	allowRowSelect?: Boolean,
 	columnsTemplate?: string,
 	selectCallback?: Number => void,
-	selectAllCallback?: Boolean => void
+	selectAllCallback?: Boolean => void,
+	sortableColumns?: Array<string>,
+	sortCallback?: (string, Boolean) => void
 };
 
 const Table = (props: TableProps) => {
@@ -80,11 +84,51 @@ const Table = (props: TableProps) => {
 					)}
 					{props.columns.map((col, index) => {
 						return (
-							<Box w='calc(100% - 10px)' p='10px' key={index}>
+							<Flex
+								w='calc(100% - 10px)'
+								p='10px'
+								py='15px'
+								key={index}
+								align='center'
+							>
 								<Text as='b' fontSize='sm' color={textColor[mode]}>
 									{col}
 								</Text>
-							</Box>
+								{props.sortableColumns.indexOf(col) > -1 && (
+									<Stack spacing={0}>
+										<IconButton
+											icon='triangle-up'
+											color={textColor[mode]}
+											p={0}
+											m={0}
+											ml={1}
+											variant='ghost'
+											size='xs'
+											height='10px'
+											fontSize='8px'
+											color={textColorLight[mode]}
+											onClick={() => {
+												props.sortCallback(col, true);
+											}}
+										></IconButton>
+										<IconButton
+											icon='triangle-down'
+											color={textColor[mode]}
+											p={0}
+											m={0}
+											ml={1}
+											variant='ghost'
+											size='xs'
+											height='10px'
+											fontSize='8px'
+											color={textColorLight[mode]}
+											onClick={() => {
+												props.sortCallback(col, false);
+											}}
+										></IconButton>
+									</Stack>
+								)}
+							</Flex>
 						);
 					})}
 				</Grid>

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,7 +41,7 @@ const getRiskSliderColor = risk => {
 	return "gray.400";
 };
 
-const textColor = { light: "2D3748", dark: "#FFF" };
+const textColor = { light: "#2D3748", dark: "#FFF" };
 const textColorLight = { light: "#677793", dark: "#ADB8CD" };
 const border = { light: "#EEF2F9", dark: "#262E3E" };
 


### PR DESCRIPTION
This PR adds the UI for the Edit Validators view:

Route for local testing: http://localhost:3000/#/edit-validators

![screencapture-localhost-3000-2020-05-10-13_39_15](https://user-images.githubusercontent.com/6816349/81494106-b61f3d00-92c3-11ea-94f5-d0cd3f3930d9.png)

Description:

Props: 
- Color mode
- Amount
- Currency
- nValidators - Number of Validators

(For Integration) Using the Table Component inside the view:

`<Table
								colorMode={mode}
								allowRowSelect={true}
								columns={[
									"Validator",
									"Staking Amt.",
									"Other Stake",
									"Own Stake",
									"Commission",
									"Points",
									"Risk Score",
									"Last #"
								]}
								rows={validators}
								selectCallback={callBack}
								selectAllCallback={selectAll}
							></Table>`

The API needs to set the state for the component that populates the table rows sent as the prop - "rows". Callback functions that are passed as props are used to manipulate the state of the validators through the table checkboxes. An example is shown in the code for reference.

Features:
- [x] Responsive
- [x] Dark Mode Compatible
- [x] Create a dynamic table component that can be used anywhere in the tool
- [x] Able to adjust columns widths of the table through props
- [x] Selection based table with select all, deselect all functionality