### PR TITLE
UI for Network Details View

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"react-icons": "^3.8.0",
 		"react-konva": "^16.10.1-0",
 		"react-media": "^1.10.0",
+		"react-range": "^1.6.3",
 		"react-router-dom": "^5.1.2",
 		"react-scripts": "^3.3.0",
 		"react-step-wizard": "^5.3.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -374,7 +374,7 @@ function App() {
 					</Route>
 					{/* Edit Validators */}
 					<Route path='/network-details-demo'>
-						<NetworkDetails colorMode={colorMode} />
+						<NetworkDetails colorMode={colorMode} currency={currency} />
 					</Route>
 					{/* Confirmation */}
 					<Route path='/confirmation'>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ import SuggestedValidators from "./components/SuggestedValidators/SuggestedValid
 import WalletConnect from "./components/WalletConnect/WalletConnect";
 import ConfirmationPage from "./components/ConfirmationPage/ConfirmationPage";
 import EditValidators from "./components/EditValidators/EditValidators";
+import NetworkDetails from "./components/NetworkDetails/NetworkDetails";
 
 const AMPLITUDE_KEY = "1f1699160a46dec6cc7514c14cb5c968";
 
@@ -206,7 +207,7 @@ function App() {
 			<Router>
 				<ScrollToTop />
 				<Route exact path='/'>
-					<Redirect to='/network-details' />
+					<Redirect to='/network-details-demo' />
 				</Route>
 				<NavBar
 					onExtensionDialogOpen={onExtensionDialogOpen}
@@ -370,6 +371,10 @@ function App() {
 							currency={currency}
 							amount={16.5}
 						/>
+					</Route>
+					{/* Edit Validators */}
+					<Route path='/network-details-demo'>
+						<NetworkDetails colorMode={colorMode} />
 					</Route>
 					{/* Confirmation */}
 					<Route path='/confirmation'>

--- a/src/components/EditValidators/Table.js
+++ b/src/components/EditValidators/Table.js
@@ -23,7 +23,7 @@ const deselect = {
 };
 
 type TableProps = {
-	colorMode?: colorMode,
+	colorMode?: "light" | "dark",
 	columns: Array<string>,
 	rows: Array<Object>,
 	allowRowSelect?: Boolean,
@@ -85,8 +85,8 @@ const Table = (props: TableProps) => {
 					{props.columns.map((col, index) => {
 						return (
 							<Flex
-								w='calc(100% - 10px)'
-								p='10px'
+								w='calc(100%)'
+								p='15px'
 								py='15px'
 								key={index}
 								align='center'

--- a/src/components/EditValidators/Table.js
+++ b/src/components/EditValidators/Table.js
@@ -141,7 +141,9 @@ const Table = (props: TableProps) => {
 							borderWidth='1px'
 							borderColor={border[mode]}
 							borderTop='0'
-							bg={row.selected ? "rgba(255,255,255,0)" : deselect[mode]}
+							bg={
+								row.selected === false ? deselect[mode] : "rgba(255,255,255,0)"
+							}
 						>
 							{props.allowRowSelect && (
 								<Flex

--- a/src/components/NetworkDetails/Filter.js
+++ b/src/components/NetworkDetails/Filter.js
@@ -92,7 +92,7 @@ const Filter = (props: FilterProps) => {
 									value={filter.values}
 									min={filter.min}
 									max={filter.max}
-									steps={0.1}
+									step={1}
 									callback={val => {
 										changeValues(index, val);
 									}}

--- a/src/components/NetworkDetails/Filter.js
+++ b/src/components/NetworkDetails/Filter.js
@@ -1,32 +1,29 @@
 import React from "react";
 import { Box, Text, Flex } from "@chakra-ui/core";
 import { textColor, textColorLight, border } from "../../constants";
-import { Slider } from "material-ui-slider";
-
-const colorScheme = {
-	primary: {
-		bg: "#19CC95",
-		color: "#FFF",
-		hoverBg: "#14AC7D"
-	},
-	secondary: {
-		bg: "#4A5567",
-		color: "#FFF",
-		hoverBg: "#2F3745"
-	},
-	white: {
-		bg: "#FFF",
-		color: "#19CC95",
-		hoverBg: "#EEE"
-	}
-};
+import RangeInput from "./RangeInput";
 
 type FilterProps = {
-	colorMode?: "light" | "dark"
+	colorMode?: "light" | "dark",
+	filters: Array<{
+		label: string,
+		type: "slider" | "range" | "input",
+		values: any,
+		min: number,
+		max: Number
+	}>,
+	callback: Array => void
 };
 
 const Filter = (props: FilterProps) => {
 	const mode = props.colorMode ? props.colorMode : "light";
+
+	const changeValues = (ind, newVal) => {
+		let temp = [...props.filters];
+		temp[ind]["values"] = newVal;
+		props.callback(temp);
+	};
+
 	return (
 		<>
 			<Box
@@ -48,39 +45,77 @@ const Filter = (props: FilterProps) => {
 					Filter
 				</Text>
 				<Box h='8px'></Box>
-				<Box
-					w='calc(100%)'
-					px='15px'
-					py='10px'
-					borderTop='1px'
-					borderColor={border[mode]}
-				>
-					<Flex justify='space-between'>
-						<Text fontSize='sm' color={textColorLight[mode]}>
-							No. of Nominators
-						</Text>
-						<Text fontSize='sm'>20k - 40k</Text>
-					</Flex>
-					{/* <Slider color='green' defaultValue={30}>
-						<SliderTrack />
-						<SliderFilledTrack />
-						<SliderThumb />
-					</Slider> */}
-				</Box>
-				<Box
-					w='calc(100%)'
-					px='15px'
-					py='10px'
-					borderTop='1px'
-					borderColor={border[mode]}
-				>
-					<Flex justify='space-between'>
-						<Text fontSize='sm' color={textColorLight[mode]}>
-							No. of Nominators
-						</Text>
-						<Text fontSize='sm'>20k - 40k</Text>
-					</Flex>
-				</Box>
+				{props.filters.map((filter, index) => {
+					return (
+						<Box
+							w='calc(100%)'
+							px='15px'
+							py='10px'
+							borderTop='1px'
+							borderColor={border[mode]}
+						>
+							<Flex justify='space-between' mb={1}>
+								<Text fontSize='xs' color={textColor[mode]}>
+									{filter.label}
+								</Text>
+								{filter.type === "range" && (
+									<Text
+										as='b'
+										fontSize='10px'
+										bg={border[mode]}
+										p={1}
+										px={2}
+										rounded='lg'
+										color={textColorLight[mode]}
+									>{`${filter.values[0]} - ${filter.values[1]} ${
+										filter.unit ? filter.unit : ""
+									}`}</Text>
+								)}
+								{filter.type === "slider" && (
+									<Text
+										as='b'
+										fontSize='10px'
+										bg={border[mode]}
+										p={1}
+										px={2}
+										rounded='lg'
+										color={textColorLight[mode]}
+									>{`${
+										filter.label === "Max. Risk Level"
+											? filter.values / 100
+											: filter.values
+									} ${filter.unit ? filter.unit : ""}`}</Text>
+								)}
+							</Flex>
+							{filter.type === "range" && (
+								<RangeInput
+									value={filter.values}
+									min={filter.min}
+									max={filter.max}
+									steps={0.1}
+									callback={val => {
+										changeValues(index, val);
+									}}
+									type='range'
+									colorMode={mode}
+								></RangeInput>
+							)}
+							{filter.type === "slider" && (
+								<RangeInput
+									value={filter.values}
+									min={filter.min}
+									max={filter.max}
+									steps={0.1}
+									callback={val => {
+										changeValues(index, val);
+									}}
+									type='slider'
+									colorMode={mode}
+								></RangeInput>
+							)}
+						</Box>
+					);
+				})}
 			</Box>
 		</>
 	);

--- a/src/components/NetworkDetails/Filter.js
+++ b/src/components/NetworkDetails/Filter.js
@@ -1,0 +1,89 @@
+import React from "react";
+import { Box, Text, Flex } from "@chakra-ui/core";
+import { textColor, textColorLight, border } from "../../constants";
+import { Slider } from "material-ui-slider";
+
+const colorScheme = {
+	primary: {
+		bg: "#19CC95",
+		color: "#FFF",
+		hoverBg: "#14AC7D"
+	},
+	secondary: {
+		bg: "#4A5567",
+		color: "#FFF",
+		hoverBg: "#2F3745"
+	},
+	white: {
+		bg: "#FFF",
+		color: "#19CC95",
+		hoverBg: "#EEE"
+	}
+};
+
+type FilterProps = {
+	colorMode?: "light" | "dark"
+};
+
+const Filter = (props: FilterProps) => {
+	const mode = props.colorMode ? props.colorMode : "light";
+	return (
+		<>
+			<Box
+				borderWidth='1px'
+				rounded='lg'
+				borderColor={border[mode]}
+				w='calc(100%)'
+				py='5px'
+			>
+				<Text
+					as='b'
+					letterSpacing='4px'
+					fontSize='xs'
+					textTransform='uppercase'
+					color={textColorLight[mode]}
+					w='calc(100% - 30px)'
+					px='15px'
+				>
+					Filter
+				</Text>
+				<Box h='8px'></Box>
+				<Box
+					w='calc(100%)'
+					px='15px'
+					py='10px'
+					borderTop='1px'
+					borderColor={border[mode]}
+				>
+					<Flex justify='space-between'>
+						<Text fontSize='sm' color={textColorLight[mode]}>
+							No. of Nominators
+						</Text>
+						<Text fontSize='sm'>20k - 40k</Text>
+					</Flex>
+					{/* <Slider color='green' defaultValue={30}>
+						<SliderTrack />
+						<SliderFilledTrack />
+						<SliderThumb />
+					</Slider> */}
+				</Box>
+				<Box
+					w='calc(100%)'
+					px='15px'
+					py='10px'
+					borderTop='1px'
+					borderColor={border[mode]}
+				>
+					<Flex justify='space-between'>
+						<Text fontSize='sm' color={textColorLight[mode]}>
+							No. of Nominators
+						</Text>
+						<Text fontSize='sm'>20k - 40k</Text>
+					</Flex>
+				</Box>
+			</Box>
+		</>
+	);
+};
+
+export default Filter;

--- a/src/components/NetworkDetails/NetworkDetails.js
+++ b/src/components/NetworkDetails/NetworkDetails.js
@@ -1,92 +1,84 @@
 import React from "react";
 import { Route } from "react-router-dom";
-import {
-	Box,
-	Heading,
-	Text,
-	Link,
-	Icon,
-	ButtonGroup,
-	Flex,
-	PseudoBox
-} from "@chakra-ui/core";
+import { Box, Heading, Flex, PseudoBox } from "@chakra-ui/core";
 import Helmet from "react-helmet";
 import Footer from "../Footer.jsx";
-import Table from "../EditValidators/Table";
 import {
 	textColor,
-	textColorLight,
 	border,
 	primaryColor,
 	primaryColorHighlight
 } from "../../constants";
 import Filter from "./Filter";
+import ValidatorsTable from "./ValidatorsTable";
+import NominatorsTable from "./NominatorsTable";
 
 type NetworkDetailsProps = {
-	colorMode?: "light" | "dark"
+	colorMode?: "light" | "dark",
+	currency: string
 };
 
 const NetworkDetails = (props: NetworkDetailsProps) => {
-	const [validators, setValidators] = React.useState([
+	const mode = props.colorMode ? props.colorMode : "light";
+
+	const [filters, setFilters] = React.useState([
 		{
-			Validator: "PolyLabs I",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "13 KSM",
-			Commission: "4%",
-			"Risk Score": 0.34,
-			selected: true
+			label: "No. of Validators",
+			type: "range",
+			values: [100, 900],
+			min: 10,
+			max: 1000
 		},
 		{
-			Validator: "PolyLabs I",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "5%",
-			"Risk Score": 0.14,
-			selected: true
+			label: "Total Stake",
+			type: "range",
+			values: [10, 40],
+			min: 0,
+			max: 50,
+			unit: props.currency
 		},
 		{
-			Validator: "PolyLabs I",
-			"Other Stake": "124.4525 KSM",
-			"Own Stake": "15 KSM",
-			Commission: "3%",
-			"Risk Score": 0.22,
-			selected: true
+			label: "Self Stake",
+			type: "range",
+			values: [10, 40],
+			min: 0,
+			max: 50,
+			unit: props.currency
 		},
 		{
-			Validator: "PolyLabs I",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "2%",
-			"Risk Score": 0.15,
-			selected: true
+			label: "Other Stake",
+			type: "range",
+			values: [10, 40],
+			min: 0,
+			max: 50,
+			unit: props.currency
 		},
 		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64,
-			selected: true
+			label: "Commission",
+			type: "range",
+			values: [10, 40],
+			min: 0,
+			max: 50,
+			unit: props.currency
+		},
+		{
+			label: "Min. Expected Daily Earning",
+			type: "slider",
+			values: [25],
+			min: 0,
+			max: 50,
+			unit: props.currency
+		},
+		{
+			label: "Max. Risk Level",
+			type: "slider",
+			values: [25],
+			min: 0,
+			max: 100
 		}
 	]);
 
 	const [currentTab, setCurrentTab] = React.useState("Validators");
-
-	const mode = props.colorMode ? props.colorMode : "light";
-
-	const sortList = (column, asc) => {
-		let tempValidators = [...validators];
-		if (asc) {
-			tempValidators = tempValidators.sort((a, b) =>
-				a[column] > b[column] ? 1 : b[column] > a[column] ? -1 : 0
-			);
-		} else {
-			tempValidators = tempValidators.sort((a, b) =>
-				a[column] > b[column] ? -1 : b[column] > a[column] ? 1 : 0
-			);
-		}
-		setValidators(tempValidators);
-	};
 
 	return (
 		<>
@@ -162,32 +154,51 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 							Nominators
 						</PseudoBox>
 					</Flex>
-					<Flex mt={8}>
-						<Box w='calc(70% - 20px)' m='10px' overflow='auto'>
+					<Flex mt={8} wrap='wrap-reverse'>
+						<Box
+							w={
+								currentTab === "Validators"
+									? [
+											"calc(100% - 20px)",
+											"calc(100% - 20px)",
+											"calc(75% - 20px)",
+											"calc(75% - 20px)"
+									  ]
+									: "calc(100% - 20px)"
+							}
+							maxH='calc(100vh - 20px)'
+							m='10px'
+							overflow='auto'
+						>
 							<Box w={["300%", "200%", "100%", "100%"]}>
-								<Table
-									colorMode={mode}
-									columns={[
-										"Validator",
-										"Other Stake",
-										"Own Stake",
-										"Commission",
-										"Risk Score"
-									]}
-									rows={validators}
-									sortableColumns={[
-										"Other Stake",
-										"Own Stake",
-										"Commission",
-										"Risk Score"
-									]}
-									sortCallback={sortList}
-								></Table>
+								{currentTab === "Validators" ? (
+									<ValidatorsTable
+										colorMode={mode}
+										filters={filters}
+										currency={props.currency}
+									/>
+								) : (
+									<NominatorsTable colorMode={mode} currency={props.currency} />
+								)}
 							</Box>
 						</Box>
-						<Box w='calc(30% - 20px)' m='10px'>
-							<Filter colorMode={mode}></Filter>
-						</Box>
+						{currentTab === "Validators" && (
+							<Box
+								w={[
+									"calc(100% - 20px)",
+									"calc(100% - 20px)",
+									"calc(25% - 20px)",
+									"calc(25% - 20px)"
+								]}
+								m='10px'
+							>
+								<Filter
+									colorMode={mode}
+									filters={filters}
+									callback={setFilters}
+								></Filter>
+							</Box>
+						)}
 					</Flex>
 				</Box>
 			</Route>

--- a/src/components/NetworkDetails/NetworkDetails.js
+++ b/src/components/NetworkDetails/NetworkDetails.js
@@ -1,0 +1,199 @@
+import React from "react";
+import { Route } from "react-router-dom";
+import {
+	Box,
+	Heading,
+	Text,
+	Link,
+	Icon,
+	ButtonGroup,
+	Flex,
+	PseudoBox
+} from "@chakra-ui/core";
+import Helmet from "react-helmet";
+import Footer from "../Footer.jsx";
+import Table from "../EditValidators/Table";
+import {
+	textColor,
+	textColorLight,
+	border,
+	primaryColor,
+	primaryColorHighlight
+} from "../../constants";
+import Filter from "./Filter";
+
+type NetworkDetailsProps = {
+	colorMode?: "light" | "dark"
+};
+
+const NetworkDetails = (props: NetworkDetailsProps) => {
+	const [validators, setValidators] = React.useState([
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "13 KSM",
+			Commission: "4%",
+			"Risk Score": 0.34,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "5%",
+			"Risk Score": 0.14,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "124.4525 KSM",
+			"Own Stake": "15 KSM",
+			Commission: "3%",
+			"Risk Score": 0.22,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "2%",
+			"Risk Score": 0.15,
+			selected: true
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64,
+			selected: true
+		}
+	]);
+
+	const [currentTab, setCurrentTab] = React.useState("Validators");
+
+	const mode = props.colorMode ? props.colorMode : "light";
+
+	const sortList = (column, asc) => {
+		let tempValidators = [...validators];
+		if (asc) {
+			tempValidators = tempValidators.sort((a, b) =>
+				a[column] > b[column] ? 1 : b[column] > a[column] ? -1 : 0
+			);
+		} else {
+			tempValidators = tempValidators.sort((a, b) =>
+				a[column] > b[column] ? -1 : b[column] > a[column] ? 1 : 0
+			);
+		}
+		setValidators(tempValidators);
+	};
+
+	return (
+		<>
+			<Helmet>
+				<title>Yield Scan &middot; Network Details</title>
+			</Helmet>
+			<Route exact path='/network-details-demo'>
+				<Box w='100%'>
+					<Heading as='h3' size='xl' color={textColor[mode]} my={4} mt={8}>
+						Network Details
+					</Heading>
+					<Flex wrap='wrap' my={8}>
+						<PseudoBox
+							as='b'
+							py={2}
+							px={4}
+							transition='all 0.2s cubic-bezier(.08,.52,.52,1)'
+							borderWidth='1px'
+							borderColor={border[mode]}
+							roundedTopLeft='20px '
+							roundedBottomLeft='20px '
+							fontSize='sm'
+							cursor='pointer'
+							color={currentTab === "Validators" ? "#FFF" : textColor[mode]}
+							bg={
+								currentTab === "Validators"
+									? primaryColor
+									: "rgba(255,255,255,0)"
+							}
+							_hover={{
+								bg: currentTab === "Validators" ? primaryColor : border[mode]
+							}}
+							boxShadow={
+								currentTab === "Validators"
+									? `0 0 0 0.2rem ${primaryColorHighlight}`
+									: "none"
+							}
+							onClick={() => {
+								setCurrentTab("Validators");
+							}}
+						>
+							Validators
+						</PseudoBox>
+						<PseudoBox
+							as='b'
+							py={2}
+							px={4}
+							transition='all 0.2s cubic-bezier(.08,.52,.52,1)'
+							borderWidth='1px'
+							borderColor={border[mode]}
+							roundedTopRight='20px'
+							roundedBottomRight='20px'
+							fontSize='sm'
+							cursor='pointer'
+							color={currentTab === "Nominators" ? "#FFF" : textColor[mode]}
+							bg={
+								currentTab === "Nominators"
+									? primaryColor
+									: "rgba(255,255,255,0)"
+							}
+							_hover={{
+								bg: currentTab === "Nominators" ? primaryColor : border[mode]
+							}}
+							boxShadow={
+								currentTab === "Nominators"
+									? `0 0 0 0.2rem ${primaryColorHighlight}`
+									: "none"
+							}
+							onClick={() => {
+								setCurrentTab("Nominators");
+							}}
+						>
+							Nominators
+						</PseudoBox>
+					</Flex>
+					<Flex mt={8}>
+						<Box w='calc(70% - 20px)' m='10px' overflow='auto'>
+							<Box w={["300%", "200%", "100%", "100%"]}>
+								<Table
+									colorMode={mode}
+									columns={[
+										"Validator",
+										"Other Stake",
+										"Own Stake",
+										"Commission",
+										"Risk Score"
+									]}
+									rows={validators}
+									sortableColumns={[
+										"Other Stake",
+										"Own Stake",
+										"Commission",
+										"Risk Score"
+									]}
+									sortCallback={sortList}
+								></Table>
+							</Box>
+						</Box>
+						<Box w='calc(30% - 20px)' m='10px'>
+							<Filter colorMode={mode}></Filter>
+						</Box>
+					</Flex>
+				</Box>
+			</Route>
+			<Footer />
+		</>
+	);
+};
+
+export default NetworkDetails;

--- a/src/components/NetworkDetails/NetworkDetails.js
+++ b/src/components/NetworkDetails/NetworkDetails.js
@@ -23,7 +23,7 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 
 	const [filters, setFilters] = React.useState([
 		{
-			label: "No. of Nominations",
+			label: "No. of Nominators",
 			type: "range",
 			values: [100, 900],
 			min: 10,

--- a/src/components/NetworkDetails/NetworkDetails.js
+++ b/src/components/NetworkDetails/NetworkDetails.js
@@ -23,7 +23,7 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 
 	const [filters, setFilters] = React.useState([
 		{
-			label: "No. of Validators",
+			label: "No. of Nominations",
 			type: "range",
 			values: [100, 900],
 			min: 10,
@@ -38,7 +38,7 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 			unit: props.currency
 		},
 		{
-			label: "Self Stake",
+			label: "Own Stake",
 			type: "range",
 			values: [10, 40],
 			min: 0,
@@ -59,7 +59,7 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 			values: [10, 40],
 			min: 0,
 			max: 50,
-			unit: props.currency
+			unit: "%"
 		},
 		{
 			label: "Min. Expected Daily Earning",
@@ -72,7 +72,7 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 		{
 			label: "Max. Risk Level",
 			type: "slider",
-			values: [25],
+			values: [50],
 			min: 0,
 			max: 100
 		}

--- a/src/components/NetworkDetails/NetworkDetails.js
+++ b/src/components/NetworkDetails/NetworkDetails.js
@@ -58,7 +58,7 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 			type: "range",
 			values: [10, 40],
 			min: 0,
-			max: 50,
+			max: 100,
 			unit: "%"
 		},
 		{
@@ -72,7 +72,7 @@ const NetworkDetails = (props: NetworkDetailsProps) => {
 		{
 			label: "Max. Risk Level",
 			type: "slider",
-			values: [50],
+			values: [100],
 			min: 0,
 			max: 100
 		}

--- a/src/components/NetworkDetails/NominatorsTable.js
+++ b/src/components/NetworkDetails/NominatorsTable.js
@@ -1,0 +1,47 @@
+import React from "react";
+import Table from "../EditValidators/Table";
+
+type NominatorsTableProps = {
+	colorMode?: "light" | "dark",
+	currency: string
+};
+
+const NominatorsTable = (props: NominatorsTableProps) => {
+	const [nominators, setNominators] = React.useState([
+		{
+			"Column 1": "Sample Name Value 1",
+			"Column 2": "Sample Numbers 042",
+			"Column 3": "Sample Text Desc"
+		}
+	]);
+
+	const mode = props.colorMode ? props.colorMode : "light";
+
+	const sortList = (column, asc) => {
+		let tempNominators = [...nominators];
+		if (asc) {
+			tempNominators = tempNominators.sort((a, b) =>
+				a[column] > b[column] ? 1 : b[column] > a[column] ? -1 : 0
+			);
+		} else {
+			tempNominators = tempNominators.sort((a, b) =>
+				a[column] > b[column] ? -1 : b[column] > a[column] ? 1 : 0
+			);
+		}
+		setNominators(tempNominators);
+	};
+
+	return (
+		<>
+			<Table
+				colorMode={mode}
+				columns={["Column 1", "Column 2", "Column 3"]}
+				rows={nominators}
+				sortableColumns={["Column 1", "Column 2", "Column 3"]}
+				sortCallback={sortList}
+			></Table>
+		</>
+	);
+};
+
+export default NominatorsTable;

--- a/src/components/NetworkDetails/RangeInput.js
+++ b/src/components/NetworkDetails/RangeInput.js
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { Range, getTrackBackground } from "react-range";
+import { primaryColor, primaryColorHighlight } from "../../constants";
+
+class RangeInput extends React.Component {
+	constructor(props) {
+		super(props);
+		this.trackColor = mode => {
+			return mode === "dark" ? "#3C475F" : "#EEF2F9";
+		};
+	}
+
+	render() {
+		return (
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "center",
+					flexWrap: "wrap"
+				}}
+			>
+				<Range
+					values={this.props.value}
+					step={this.props.step}
+					min={this.props.min}
+					max={this.props.max}
+					onChange={values => {
+						this.props.callback(values);
+					}}
+					renderTrack={({ props, children }) => (
+						<div
+							onMouseDown={props.onMouseDown}
+							onTouchStart={props.onTouchStart}
+							style={{
+								...props.style,
+								height: "14px",
+								display: "flex",
+								width: "100%"
+							}}
+						>
+							<div
+								ref={props.ref}
+								style={{
+									height: "4px",
+									width: "100%",
+									borderRadius: "4px",
+									background: getTrackBackground({
+										values: this.props.value,
+										colors:
+											this.props.type === "range"
+												? [
+														this.trackColor(this.props.colorMode),
+														primaryColor,
+														this.trackColor(this.props.colorMode)
+												  ]
+												: [primaryColor, this.trackColor(this.props.colorMode)],
+										min: this.props.min,
+										max: this.props.max
+									}),
+									alignSelf: "center"
+								}}
+							>
+								{children}
+							</div>
+						</div>
+					)}
+					renderThumb={({ props, isDragged }) => (
+						<div
+							{...props}
+							style={{
+								...props.style,
+								height: isDragged ? "18px" : "14px",
+								width: isDragged ? "18px" : "14px",
+								borderRadius: "100%",
+								backgroundColor: "#FFF",
+								display: "flex",
+								justifyContent: "center",
+								alignItems: "center",
+								cursor: "pointer",
+								boxShadow: isDragged
+									? `0px 0px 0px 0.3rem ${primaryColorHighlight}`
+									: "0px 1px 5px rgba(0,0,0,0.2)",
+								outline: "none"
+							}}
+						></div>
+					)}
+				/>
+			</div>
+		);
+	}
+}
+
+export default RangeInput;

--- a/src/components/NetworkDetails/ValidatorsTable.js
+++ b/src/components/NetworkDetails/ValidatorsTable.js
@@ -11,96 +11,76 @@ const ValidatorsTable = (props: ValidatorsTableProps) => {
 	const [validators, setValidators] = React.useState([
 		{
 			Validator: "PolyLabs I",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "13 KSM",
-			Commission: "4%",
+			"No. of Nominations": 300,
+			"Other Stake": 10.4525,
+			"Own Stake": 13,
+			Commission: 4,
 			"Risk Score": 0.34
 		},
 		{
 			Validator: "PolyLabs I",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "5%",
+			"No. of Nominations": 50,
+			"Other Stake": 1.4525,
+			"Own Stake": 33,
+			Commission: 4,
+			"Risk Score": 0.04
+		},
+		{
+			Validator: "PolyLabs I",
+			"No. of Nominations": 150,
+			"Other Stake": 13.4525,
+			"Own Stake": 103,
+			Commission: 5,
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"No. of Nominations": 2000,
+			"Other Stake": 3.4525,
+			"Own Stake": 3,
+			Commission: 7,
+			"Risk Score": 0.7
+		},
+		{
+			Validator: "PolyLabs I",
+			"No. of Nominations": 4750,
+			"Other Stake": 22.4525,
+			"Own Stake": 1003,
+			Commission: 18,
+			"Risk Score": 0.3
+		},
+		{
+			Validator: "PolyLabs I",
+			"No. of Nominations": 42,
+			"Other Stake": 1345.25,
+			"Own Stake": 4242,
+			Commission: 2,
 			"Risk Score": 0.14
 		},
 		{
 			Validator: "PolyLabs I",
-			"Other Stake": "124.4525 KSM",
-			"Own Stake": "15 KSM",
-			Commission: "3%",
-			"Risk Score": 0.22
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "13.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "2%",
-			"Risk Score": 0.15
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
-		},
-		{
-			Validator: "PolyLabs I",
-			"Other Stake": "53.4525 KSM",
-			"Own Stake": "12 KSM",
-			Commission: "3%",
-			"Risk Score": 0.64
+			"No. of Nominations": 7,
+			"Other Stake": 525,
+			"Own Stake": 1600,
+			Commission: 19,
+			"Risk Score": 0.24
 		}
 	]);
+
+	const parseValidators = valArr => {
+		let parseArr = [];
+		valArr.map((doc, i) => {
+			parseArr.push({
+				Validator: doc["Validator"],
+				"No. of Nominations": doc["No. of Nominations"],
+				"Other Stake": `${doc["Other Stake"]} ${props.currency}`,
+				"Own Stake": `${doc["Own Stake"]} ${props.currency}`,
+				Commission: `${doc["Commission"]}%`,
+				"Risk Score": doc["Risk Score"]
+			});
+		});
+		return parseArr;
+	};
 
 	const mode = props.colorMode ? props.colorMode : "light";
 
@@ -124,13 +104,15 @@ const ValidatorsTable = (props: ValidatorsTableProps) => {
 				colorMode={mode}
 				columns={[
 					"Validator",
+					"No. of Nominations",
 					"Other Stake",
 					"Own Stake",
 					"Commission",
 					"Risk Score"
 				]}
-				rows={validators}
+				rows={parseValidators(validators)}
 				sortableColumns={[
+					"No. of Nominations",
 					"Other Stake",
 					"Own Stake",
 					"Commission",

--- a/src/components/NetworkDetails/ValidatorsTable.js
+++ b/src/components/NetworkDetails/ValidatorsTable.js
@@ -1,0 +1,145 @@
+import React from "react";
+import Table from "../EditValidators/Table";
+
+type ValidatorsTableProps = {
+	colorMode?: "light" | "dark",
+	currency: string,
+	filters?: Array<{}>
+};
+
+const ValidatorsTable = (props: ValidatorsTableProps) => {
+	const [validators, setValidators] = React.useState([
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "13 KSM",
+			Commission: "4%",
+			"Risk Score": 0.34
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "5%",
+			"Risk Score": 0.14
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "124.4525 KSM",
+			"Own Stake": "15 KSM",
+			Commission: "3%",
+			"Risk Score": 0.22
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "13.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "2%",
+			"Risk Score": 0.15
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		},
+		{
+			Validator: "PolyLabs I",
+			"Other Stake": "53.4525 KSM",
+			"Own Stake": "12 KSM",
+			Commission: "3%",
+			"Risk Score": 0.64
+		}
+	]);
+
+	const mode = props.colorMode ? props.colorMode : "light";
+
+	const sortList = (column, asc) => {
+		let tempValidators = [...validators];
+		if (asc) {
+			tempValidators = tempValidators.sort((a, b) =>
+				a[column] > b[column] ? 1 : b[column] > a[column] ? -1 : 0
+			);
+		} else {
+			tempValidators = tempValidators.sort((a, b) =>
+				a[column] > b[column] ? -1 : b[column] > a[column] ? 1 : 0
+			);
+		}
+		setValidators(tempValidators);
+	};
+
+	return (
+		<>
+			<Table
+				colorMode={mode}
+				columns={[
+					"Validator",
+					"Other Stake",
+					"Own Stake",
+					"Commission",
+					"Risk Score"
+				]}
+				rows={validators}
+				sortableColumns={[
+					"Other Stake",
+					"Own Stake",
+					"Commission",
+					"Risk Score"
+				]}
+				sortCallback={sortList}
+			></Table>
+		</>
+	);
+};
+
+export default ValidatorsTable;

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,6 +44,8 @@ const getRiskSliderColor = risk => {
 const textColor = { light: "#2D3748", dark: "#FFF" };
 const textColorLight = { light: "#677793", dark: "#ADB8CD" };
 const border = { light: "#EEF2F9", dark: "#262E3E" };
+const primaryColor = "#19CC95";
+const primaryColorHighlight = "#19CC9533";
 
 export {
 	LOW_RISK,
@@ -53,5 +55,7 @@ export {
 	getRiskLevel,
 	textColor,
 	textColorLight,
-	border
+	border,
+	primaryColor,
+	primaryColorHighlight
 };


### PR DESCRIPTION
This PR adds the UI for the Network Details view:

Route for local testing: http://localhost:3000/#/network-details-demo

![screencapture-localhost-3000-2020-05-13-23_08_33](https://user-images.githubusercontent.com/6816349/81846056-21406c00-956f-11ea-8bea-50356ba64aa7.png)

Description: 

Contains 3 main components:
- Filter: The filters state is created in the NetworkDetails component and passes an array of objects as a prop to customize filters as required. The state updates with changes in the component and is passed to the validators table for tuning.
- Validators Table: Will be used to call the API to access validator data and render the table. Sorting allowed
- Nominators Table: Will be used to call the API to access nominator data and render the table. Sorting allowed.
(All components are dynamic and can be customized by simply adding, removing props)

Features:

- [x] Mobile friendly
- [x] Dark mode compatible
- [x] Customizable components through props

